### PR TITLE
remove 60 delay for dns propagation

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,0 @@
----
-- name: Pause 60 seconds for DNS propagation
-  pause:
-    minutes: 1

--- a/tasks/create/instance.yml
+++ b/tasks/create/instance.yml
@@ -66,7 +66,6 @@
     value: "{{ item.public_dns_name }}"
     ttl: 300
   with_items: instance.tagged_instances
-  notify: Pause 60 seconds for DNS propagation
   tags:
     - dns
 


### PR DESCRIPTION
with forge this happens locally and not dependant on dns