### PR TITLE
Changing SSH port on management to 10443 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,8 @@ forge_region: eu-central-1
 forge_bucket: telusdigital-forge
 forge_userdata: I2Nsb3VkLWNvbmZpZwpyZXBvX3VwZGF0ZTogdHJ1ZQpyZXBvX3VwZ3JhZGU6IGFsbAoKcGFja2FnZXM6CiAtIHB5dGhvbi1kZXYKIC0gcHl0aG9uLXBpcAogLSBnaXQKcnVuY21kOgogLSBjdXJsIGh0dHBzOi8vcmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbS90ZWx1c2RpZ2l0YWwvZm9yZ2UvbWFzdGVyL2Jvb3RzdHJhcC5weSB8IHB5dGhvbgo=
 
+fallback_mode: false
+
 virtualization_type: hvm
 
 health_check_response_timeout: "{% if autoscale %}2{% else %}5{% endif %}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,8 +15,6 @@ forge_region: eu-central-1
 forge_bucket: telusdigital-forge
 forge_userdata: I2Nsb3VkLWNvbmZpZwpyZXBvX3VwZGF0ZTogdHJ1ZQpyZXBvX3VwZ3JhZGU6IGFsbAoKcGFja2FnZXM6CiAtIHB5dGhvbi1kZXYKIC0gcHl0aG9uLXBpcAogLSBnaXQKcnVuY21kOgogLSBjdXJsIGh0dHBzOi8vcmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbS90ZWx1c2RpZ2l0YWwvZm9yZ2UvbWFzdGVyL2Jvb3RzdHJhcC5weSB8IHB5dGhvbgo=
 
-fallback_mode: false
-
 virtualization_type: hvm
 
 health_check_response_timeout: "{% if autoscale %}2{% else %}5{% endif %}"

--- a/vars/infrastructure/security-groups.yml
+++ b/vars/infrastructure/security-groups.yml
@@ -50,6 +50,7 @@ security_group:
     description: "Nodes that Manage Other Nodes"
     rules:
     - { proto: tcp, from_port: 22,  to_port: 22,  cidr_ip: 0.0.0.0/0 }
+    - { proto: tcp, from_port: 10443,  to_port: 10443,  cidr_ip: 0.0.0.0/0 }
     - { proto: tcp, from_port: 443, to_port: 443, cidr_ip: 0.0.0.0/0 }
   managed:
     description: "Nodes Managed by Other Nodes"

--- a/vars/infrastructure/security-groups.yml
+++ b/vars/infrastructure/security-groups.yml
@@ -51,7 +51,6 @@ security_group:
     rules:
     - { proto: tcp, from_port: 22,    to_port: 22,    cidr_ip: 0.0.0.0/0 }
     - { proto: tcp, from_port: 10443, to_port: 10443, cidr_ip: 0.0.0.0/0 }
-    - { proto: tcp, from_port: 443,   to_port: 443,   cidr_ip: 0.0.0.0/0 }
   managed:
     description: "Nodes Managed by Other Nodes"
     rules:

--- a/vars/infrastructure/security-groups.yml
+++ b/vars/infrastructure/security-groups.yml
@@ -49,8 +49,9 @@ security_group:
   management:
     description: "Nodes that Manage Other Nodes"
     rules:
-    - { proto: tcp, from_port: 22,  to_port: 22,  cidr_ip: 0.0.0.0/0 }
-    - { proto: tcp, from_port: 10443,  to_port: 10443,  cidr_ip: 0.0.0.0/0 }
+    - { proto: tcp, from_port: 22,    to_port: 22,    cidr_ip: 0.0.0.0/0 }
+    - { proto: tcp, from_port: 10443, to_port: 10443, cidr_ip: 0.0.0.0/0 }
+    - { proto: tcp, from_port: 443,   to_port: 443,   cidr_ip: 0.0.0.0/0 }
   managed:
     description: "Nodes Managed by Other Nodes"
     rules:

--- a/vars/infrastructure/security-groups.yml
+++ b/vars/infrastructure/security-groups.yml
@@ -51,7 +51,6 @@ security_group:
     rules:
     - { proto: tcp, from_port: 22,  to_port: 22,  cidr_ip: 0.0.0.0/0 }
     - { proto: tcp, from_port: 10443,  to_port: 10443,  cidr_ip: 0.0.0.0/0 }
-    - { proto: tcp, from_port: 443, to_port: 443, cidr_ip: 0.0.0.0/0 }
   managed:
     description: "Nodes Managed by Other Nodes"
     rules:

--- a/vars/infrastructure/security-groups.yml
+++ b/vars/infrastructure/security-groups.yml
@@ -135,7 +135,7 @@ security_group:
   build:
     description: "Build Nodes"
     rules:
-    - { proto: tcp, from_port: 80,    to_port: 80,   cidr_ip: 0.0.0.0/0 }
+    - { proto: tcp, from_port: 80,    to_port: 80,    cidr_ip: 0.0.0.0/0 }
     - { proto: tcp, from_port: 10555, to_port: 10555, cidr_ip: 0.0.0.0/0 }  # Robot Sweatshop / HTTP API - Used to run jobs
   preview:
     description: "Preview Nodes"


### PR DESCRIPTION
This is to maintain consistency for all projects behind the corp proxy. 443 only works for some projects, but 10443 works for all projects. 