### PR TITLE
Allowing more granular control of spot instances in environments

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,13 +29,6 @@ health_check_interval: "{% if autoscale %}5{% else %}30{% endif %}"
 health_check_unhealthy_threshold: 2
 health_check_healthy_threshold: 10
 
-always_use_spot_instance_for_roles:
-  - aggregator
-  - logs
-  - metrics
-  - build
-  - preview
-
 autoscale_roles:
   - management
   - inbound
@@ -78,11 +71,6 @@ fallback_instance_type:
   preview: m1.small
   logs: hi1.4xlarge
   metrics: hi1.4xlarge
-
-use_spot_instances_in_environments:
-  - next
-  - development
-  - staging
 
 default_instance_bid:
   c1.medium: 0.130

--- a/tasks/create/instance.yml
+++ b/tasks/create/instance.yml
@@ -42,7 +42,7 @@
         delete_on_termination: yes
         volume_size: "{{ override_root_volume_size[system_role] if system_role in override_root_volume_size else root_volume_size }}"
 
-    spot_price: "{{ instance_bid[instance_type[system_role]] if environment_tier not in ['production'] or system_role in always_use_spot_instance_for_roles else None }}"
+    spot_price: "{{ instance_bid[instance_type[system_role]] if system_role in use_spot_instances_for_roles else None }}"
     wait: yes
 
     vpc_subnet_id: "{{ vpc.subnets | selectattr('resource_tags.Role', 'equalto', system_role) | selectattr('az', 'equalto', region+preferred_availability_zone) | join(',', attribute='id') }}"
@@ -83,7 +83,7 @@
     - dns
 
 - name: "Assign Elastic IP | DNS Load Balancing | {{ system_role }}"
-  ec2_eip: 
+  ec2_eip:
     state: present
     in_vpc: yes
     region: "{{ region }}"

--- a/vars/environment_tier/development.yml
+++ b/vars/environment_tier/development.yml
@@ -1,5 +1,19 @@
---- 
+---
 environment_tier: development
 default_region: us-west-1
 region: "{% if override_region != '' %}{{ override_region }}{% else %}{{ default_region }}{% endif %}"
 dns_points_to_load_balancer: no
+use_spot_instances_for_roles:
+  - aggregator
+  - application
+  - applicationapi
+  - applicationq
+  - build
+  - cache
+  - database
+  - inbound
+  - logs
+  - management
+  - metrics
+  - outbound
+  - preview

--- a/vars/environment_tier/next.yml
+++ b/vars/environment_tier/next.yml
@@ -1,5 +1,19 @@
---- 
+---
 environment_tier: next
 default_region: eu-west-1
 region: "{% if override_region != '' %}{{ override_region }}{% else %}{{ default_region }}{% endif %}"
 dns_points_to_load_balancer: no
+use_spot_instances_for_roles:
+  - aggregator
+  - application
+  - applicationapi
+  - applicationq
+  - build
+  - cache
+  - database
+  - inbound
+  - logs
+  - management
+  - metrics
+  - outbound
+  - preview

--- a/vars/environment_tier/production.yml
+++ b/vars/environment_tier/production.yml
@@ -1,5 +1,11 @@
---- 
+---
 environment_tier: production
 default_region: us-east-1
 region: "{% if override_region != '' %}{{ override_region }}{% else %}{{ default_region }}{% endif %}"
 dns_points_to_load_balancer: "{{ load_balancers_enabled | bool }}"
+use_spot_instances_for_roles:
+  - aggregator
+  - build
+  - logs
+  - metrics
+  - preview

--- a/vars/environment_tier/staging.yml
+++ b/vars/environment_tier/staging.yml
@@ -1,5 +1,17 @@
---- 
+---
 environment_tier: staging
 default_region: us-west-2
 region: "{% if override_region != '' %}{{ override_region }}{% else %}{{ default_region }}{% endif %}"
 dns_points_to_load_balancer: "{{ load_balancers_enabled | bool }}"
+use_spot_instances_for_roles:
+  - aggregator
+  - application
+  - applicationapi
+  - applicationq
+  - build
+  - inbound
+  - logs
+  - management
+  - metrics
+  - outbound
+  - preview


### PR DESCRIPTION
Having spot instances for cache and database systems go down in staging has previously been a pain. Developers need production like data in their staging database, having these systems go down means that when they spin up new staging boxes they have to reimport data from production. This halts release flow and costs teams time. We can save all this time by instead having 2 boxes in the staging environment not on spot instances.

I tested this out using a test project in development, staging, and production. The test project had two boxes; application, database.

Dev = both spot.
Staging = database not spot, app spot.
Prod = both non spot. 

Please let me know what you think. 
