### PR TITLE
Removing robot sweatshop rules for aws security groups

### DIFF
--- a/vars/infrastructure/security-groups.yml
+++ b/vars/infrastructure/security-groups.yml
@@ -28,21 +28,18 @@ no_inbound:
     rules:
     - { proto: tcp, from_port: 80,    to_port: 80,    cidr_ip: 0.0.0.0/0 }
     - { proto: tcp, from_port: 443,   to_port: 443,   cidr_ip: 0.0.0.0/0 }
-    - { proto: tcp, from_port: 10555, to_port: 10555, cidr_ip: "{{ '0.0.0.0/0' if autodeploy_passthrough_enabled else '127.0.0.1/32' }}" }  # Robot Sweatshop / HTTP API - Used to run jobs
     - { proto: tcp, from_port: 81,    to_port: 81,    cidr_ip: "{{ '0.0.0.0/0' if autodeploy_passthrough_enabled else '127.0.0.1/32' }}" }
   applicationapi:
     description: "Applicationapi Nodes"
     rules:
     - { proto: tcp, from_port: 80,    to_port: 80,    cidr_ip: 0.0.0.0/0 }
     - { proto: tcp, from_port: 443,   to_port: 443,   cidr_ip: 0.0.0.0/0 }
-    - { proto: tcp, from_port: 10555, to_port: 10555, cidr_ip: "{{ '0.0.0.0/0' if autodeploy_passthrough_enabled else '127.0.0.1/32' }}" }  # Robot Sweatshop / HTTP API - Used to run jobs
     - { proto: tcp, from_port: 81,    to_port: 81,    cidr_ip: "{{ '0.0.0.0/0' if autodeploy_passthrough_enabled else '127.0.0.1/32' }}" }
   applicationq:
     description: "Applicationq Nodes"
     rules:
     - { proto: tcp, from_port: 80,    to_port: 80,    cidr_ip: 0.0.0.0/0 }
     - { proto: tcp, from_port: 443,   to_port: 443,   cidr_ip: 0.0.0.0/0 }
-    - { proto: tcp, from_port: 10555, to_port: 10555, cidr_ip: "{{ '0.0.0.0/0' if autodeploy_passthrough_enabled else '127.0.0.1/32' }}" }  # Robot Sweatshop / HTTP API - Used to run jobs
     - { proto: tcp, from_port: 81,    to_port: 81,    cidr_ip: "{{ '0.0.0.0/0' if autodeploy_passthrough_enabled else '127.0.0.1/32' }}" }
 
 security_group:
@@ -65,28 +62,24 @@ security_group:
     - { proto: tcp, from_port: 80,    to_port: 80,    cidr_ip: 0.0.0.0/0 }
     - { proto: tcp, from_port: 81,    to_port: 81,    cidr_ip: "{{ '0.0.0.0/0' if autodeploy_passthrough_enabled else '127.0.0.1/32' }}" }
     - { proto: tcp, from_port: 443,   to_port: 443,   cidr_ip: 0.0.0.0/0 }
-    - { proto: tcp, from_port: 10555, to_port: 10555, cidr_ip: "{{ '0.0.0.0/0' if autodeploy_passthrough_enabled else '127.0.0.1/32' }}" }  # Robot Sweatshop / HTTP API - Used to run jobs
   application:
     description: "Application Nodes"
     rules:
     - { proto: tcp, from_port: 80,    to_port: 80,    group_id: "{{ security_group_id['inbound']|default(-1) }}" }
     - { proto: tcp, from_port: 81,    to_port: 81,    group_id: "{{ security_group_id['inbound']|default(-1) if autodeploy_passthrough_enabled else security_group_id['management']|default(-1) }}" }
     - { proto: tcp, from_port: 443,   to_port: 443,   group_id: "{{ security_group_id['inbound']|default(-1) }}" }
-    - { proto: tcp, from_port: 10555, to_port: 10555, group_id: "{{ security_group_id['inbound']|default(-1) if autodeploy_passthrough_enabled else security_group_id['management']|default(-1) }}" }  # Robot Sweatshop / HTTP API - Used to run jobs
   applicationapi:
     description: "Applicationapi Nodes"
     rules:
     - { proto: tcp, from_port: 80,    to_port: 80,    group_id: "{{ security_group_id['inbound']|default(-1) }}" }
     - { proto: tcp, from_port: 81,    to_port: 81,    group_id: "{{ security_group_id['inbound']|default(-1) if autodeploy_passthrough_enabled else security_group_id['management']|default(-1) }}" }
     - { proto: tcp, from_port: 443,   to_port: 443,   group_id: "{{ security_group_id['inbound']|default(-1) }}" }
-    - { proto: tcp, from_port: 10555, to_port: 10555, group_id: "{{ security_group_id['inbound']|default(-1) if autodeploy_passthrough_enabled else security_group_id['management']|default(-1) }}" }  # Robot Sweatshop / HTTP API - Used to run jobs
   applicationq:
     description: "Applicationq Nodes"
     rules:
     - { proto: tcp, from_port: 80,    to_port: 80,    group_id: "{{ security_group_id['inbound']|default(-1) }}" }
     - { proto: tcp, from_port: 81,    to_port: 81,    group_id: "{{ security_group_id['inbound']|default(-1) if autodeploy_passthrough_enabled else security_group_id['management']|default(-1) }}" }
     - { proto: tcp, from_port: 443,   to_port: 443,   group_id: "{{ security_group_id['inbound']|default(-1) }}" }
-    - { proto: tcp, from_port: 10555, to_port: 10555, group_id: "{{ security_group_id['inbound']|default(-1) if autodeploy_passthrough_enabled else security_group_id['management']|default(-1) }}" }  # Robot Sweatshop / HTTP API - Used to run jobs
   cache:
     description: "Cache Nodes"
     rules:
@@ -147,7 +140,6 @@ security_group:
     description: "Build Nodes"
     rules:
     - { proto: tcp, from_port: 80,    to_port: 80,    cidr_ip: 0.0.0.0/0 }
-    - { proto: tcp, from_port: 10555, to_port: 10555, cidr_ip: 0.0.0.0/0 }  # Robot Sweatshop / HTTP API - Used to run jobs
   preview:
     description: "Preview Nodes"
     rules:


### PR DESCRIPTION
[Robot sweatshop](https://github.com/JScott/robot_sweatshop) is a CI server that was built by a member of the TELUS digital team a while back.

While we appreciate their contribution, they are no longer working with TELUS.  We have decided as a devops team not to use it in our infrastructure a while back, but apparently we glossed over this repo.

I'm removing all reference to it in here, and closing up ports that it would have used. 