### PR TITLE
Adding defualt var rds_engine

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,12 +15,16 @@ dns_load_balanced_roles:
 
 root_volume_size: 10
 subnet_prefix: '10.0'
+
 using_rds: no
+# [postgres, mysql]
+rds_engine: postgres
+
 using_elasticache: no
 # [memcached, redis]
 elasticache_engine: redis
-fallback_server_type: no
 
+fallback_server_type: no
 forge_region: eu-central-1
 forge_bucket: telusdigital-forge
 forge_userdata: I2Nsb3VkLWNvbmZpZwpyZXBvX3VwZGF0ZTogdHJ1ZQpyZXBvX3VwZ3JhZGU6IGFsbAoKcGFja2FnZXM6CiAtIHB5dGhvbi1kZXYKIC0gcHl0aG9uLXBpcAogLSBnaXQKcnVuY21kOgogLSBjdXJsIGh0dHBzOi8vcmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbS90ZWx1c2RpZ2l0YWwvZm9yZ2UvbWFzdGVyL2Jvb3RzdHJhcC5weSB8IHB5dGhvbgo=

--- a/tasks/create/rds-database.yml
+++ b/tasks/create/rds-database.yml
@@ -21,10 +21,10 @@
     vpc_security_groups: "{{ security_group_id[system_role] }}"
     subnet: "{{ project }}-{{ system_role }}"
 
-    db_engine: "{{ database_engine | mandatory }}"
+    db_engine: "{{ rds_engine }}"
     upgrade: yes
 
-    port: "{% if database_engine == 'postgres' %}5432{%elif database_engine == 'MySQL' %}3306{% endif %}"
+    port: "{% if rds_engine == 'postgres' %}5432{%elif rds_engine == 'mysql' %}3306{% endif %}"
     db_name: "{{ database_name | default(project) }}"
     username: "{{ database_username | default(project) }}"
     password: "{{ database_password | mandatory }}"


### PR DESCRIPTION
Adding a default var instead of waiting to fail out to realize you need to set `database_engine`. I set it to `rds_engine` to be more clear about the variable you are really setting. 
