### PR TITLE
Cchanging name from elb to load_balancer

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,13 +2,13 @@
 autodeploy_passthrough_enabled: no
 autoscale: no
 
-elb_ssl_offload: no
-elb_ssl_certificate_name: 'self-signed'
-
-load_balance_prototypes: no
+# Load Balancing
+load_balancer_ssl_offload: no
+load_balancer_ssl_certificate_name: 'self-signed'
 load_balancers_enabled: no
 dns_points_to_load_balancer: "{{ load_balancers_enabled | bool }}"
 
+# DNS Load Balancing
 dns_load_balancing_enabled: no
 dns_load_balanced_roles:
   - application

--- a/vars/infrastructure/load-balancers.yml
+++ b/vars/infrastructure/load-balancers.yml
@@ -8,11 +8,11 @@ load_balancer:
       load_balancer_port: 80
       instance_port: 80
       application: webserver
-    - protocol: "{{ 'https' if elb_ssl_offload else 'tcp' }}"
+    - protocol: "{{ 'https' if load_balancer_ssl_offload else 'tcp' }}"
       load_balancer_port: 443
-      instance_port: "{{ 80 if elb_ssl_offload else 443 }}"
-      instance_protocol: "{{ 'http' if elb_ssl_offload else 'tcp' }}"
-      ssl_certificate_id: "{{ ( 'arn:aws:iam::461957644563:server-certificate/' + elb_ssl_certificate_name ) if elb_ssl_offload else omit }}"
+      instance_port: "{{ 80 if load_balancer_ssl_offload else 443 }}"
+      instance_protocol: "{{ 'http' if load_balancer_ssl_offload else 'tcp' }}"
+      ssl_certificate_id: "{{ ( 'arn:aws:iam::461957644563:server-certificate/' + load_balancer_ssl_certificate_name ) if load_balancer_ssl_offload else omit }}"
       application: securewebserver
   database:
     scheme: internal


### PR DESCRIPTION
Making this var more clear. Why have `elb` and `load_balancer` when we can have just one?