### PR TITLE
Adding autoscaling alarms

### DIFF
--- a/tasks/create/autoscaling.yml
+++ b/tasks/create/autoscaling.yml
@@ -1,3 +1,4 @@
+
 ---
 - name: "Create AMI | {{ system_role }}"
   ec2_ami:
@@ -33,9 +34,9 @@
     launch_config_name: "{{ project }}-{{ system_role }}-{{ timestamp }}"
     load_balancers: "{% if has_load_balancer %}{{ project }}-{{ system_role }}{% else %}{{ [] }}{% endif %}"
     name: "{{ project }}-{{ system_role }}"
-    min_size: 2
-    max_size: 8
-    desired_capacity: 2
+    min_size: 3
+    max_size: 9
+    desired_capacity: 3
     vpc_zone_identifier: "{{ vpc.subnets | selectattr('resource_tags.Role', 'equalto', system_role) | join(',', attribute='id') }}"
     tags:
       - Environment: "{{ environment_tier }}"
@@ -62,13 +63,14 @@
       adjustment_type: "ChangeInCapacity"
       scaling_adjustment: +1
       min_adjustment_step: 1
-      cooldown: 180
+      cooldown: 60
     - name: "Decrease Group Size"
       adjustment_type: "ChangeInCapacity"
       scaling_adjustment: -1
       min_adjustment_step: 1
-      cooldown: 300
+      cooldown: 180
   register: autoscale_policy
+
 
 - name: "Autoscaling Alarm | High CPU | {{ system_role }}"
   ec2_metric_alarm:

--- a/tasks/create/autoscaling.yml
+++ b/tasks/create/autoscaling.yml
@@ -9,6 +9,7 @@
   register: ami
   when: system_role in autoscale_roles
 
+
 - name: "Launch Configuration | {{ system_role }}"
   ec2_lc:
     state: present
@@ -23,6 +24,7 @@
     user_data: "{{ forge_userdata | b64decode }}"
   when: system_role in autoscale_roles
 
+
 - name: "AutoScaling Group | {{ system_role }}"
   ec2_asg:
     state: present
@@ -31,9 +33,9 @@
     launch_config_name: "{{ project }}-{{ system_role }}-{{ timestamp }}"
     load_balancers: "{% if has_load_balancer %}{{ project }}-{{ system_role }}{% else %}{{ [] }}{% endif %}"
     name: "{{ project }}-{{ system_role }}"
-    min_size: 3
-    max_size: 6
-    desired_capacity: 3
+    min_size: 2
+    max_size: 8
+    desired_capacity: 2
     vpc_zone_identifier: "{{ vpc.subnets | selectattr('resource_tags.Role', 'equalto', system_role) | join(',', attribute='id') }}"
     tags:
       - Environment: "{{ environment_tier }}"
@@ -42,5 +44,60 @@
       - Name:        "{{ system_role }}.{{ project }}-{{ environment_tier }}"
       - ForgeRegion: "{{ forge_region }}"
       - ForgeBucket: "{{ forge_bucket }}"
-
   when: system_role in autoscale_roles
+
+
+- name: "Autoscaling Policies | {{ system_role }}"
+  ec2_scaling_policy:
+    state: present
+    region: "{{ region }}"
+    name: "{{ item.name }}"
+    asg_name: "{{ project }}-{{ system_role }}"
+    adjustment_type: "{{ item.adjustment_type }}"
+    min_adjustment_step: "{{ item.min_adjustment_step }}"
+    scaling_adjustment: "{{ item.scaling_adjustment }}"
+    cooldown: "{{ item.cooldown }}"
+  with_items:
+    - name: "Increase Group Size"
+      adjustment_type: "ChangeInCapacity"
+      scaling_adjustment: +1
+      min_adjustment_step: 1
+      cooldown: 180
+    - name: "Decrease Group Size"
+      adjustment_type: "ChangeInCapacity"
+      scaling_adjustment: -1
+      min_adjustment_step: 1
+      cooldown: 300
+  register: autoscale_policy
+
+- name: "Autoscaling Alarm | High CPU | {{ system_role }}"
+  ec2_metric_alarm:
+    state: present
+    region: "{{ region }}"
+    name: "{{ project }}-{{ system_role }}-scale-up"
+    metric: CPUUtilization
+    statistic: Average
+    unit: Percent
+    comparison: ">="
+    threshold: 50.0
+    evaluation_periods: 5
+    period: 60
+    namespace: AWS/EC2
+    alarm_actions: "{{ autoscale_policy.results[0].arn }}"
+
+
+- name: "Autoscaling Alarm | Low CPU | {{ system_role }}"
+  ec2_metric_alarm:
+    state: present
+    region: "{{ region }}"
+    name: "{{ project }}-{{ system_role }}-scale-down"
+    metric: CPUUtilization
+    statistic: Average
+    unit: Percent
+    comparison: ">="
+    threshold: 20.0
+    evaluation_periods: 5
+    period: 60
+    namespace: AWS/EC2
+    alarm_actions: "{{ autoscale_policy.results[1].arn }}"
+


### PR DESCRIPTION
Adding CPU Alarms for autoscaling. We didn't have anything enabled by default before. We've basically been using autoscaling groups without the main benefit of autoscaling groups. 