### PR TITLE
Remove management from autoscale'd

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,7 +51,6 @@ always_use_spot_instance_for_roles:
   - preview
 
 autoscale_roles:
-  - management
   - inbound
   - application
   - applicationapi


### PR DESCRIPTION
I don't think we ever autoscale the management boxes.. Correct me if wrong. It's also annoying when you want to autoscale your application instances, but your management instances get autoscaled too